### PR TITLE
Remove deprecated Package Control property

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -16,7 +16,6 @@ from SublimeLinter.lint import Linter, util
 class Credo(Linter):
     """Provides an interface to credo."""
 
-    syntax = 'elixir'
     cmd = 'mix credo --format=flycheck @'
     executable = 'elixir'
     version_args = '--version'
@@ -33,7 +32,9 @@ class Credo(Linter):
     error_stream = util.STREAM_BOTH
     selectors = {}
     word_re = None
-    defaults = {}
+    defaults = {
+        'selector': 'source.ex - meta.attribute-with-value, source.exs, source.eex'
+    }
     inline_settings = None
     inline_overrides = None
     comment_re = None


### PR DESCRIPTION
`Syntax` has been deprecated in favor of `defaults{selector}` and will throw a warning in Sublime. This PR fixes that. [Source](http://www.sublimelinter.com/en/stable/linter_settings.html#selector)