### PR TITLE
Cleanup deprecated config

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -17,10 +17,6 @@ class Credo(Linter):
     """Provides an interface to credo."""
 
     cmd = 'mix credo --format=flycheck @'
-    executable = 'elixir'
-    version_args = '--version'
-    version_re = r'(?P<version>\d+\.\d+\.\d+)'
-    version_requirement = '>= 1.0'
     regex = (
         r'^.+?:(?P<line>\d+):((?P<col>\d+):)? '
         r'(?:(?P<error>[W])|(?P<warning>[R|F|C])): '
@@ -30,12 +26,7 @@ class Credo(Linter):
     line_col_base = (1, 1)
     tempfile_suffix = None
     error_stream = util.STREAM_BOTH
-    selectors = {}
     word_re = None
     defaults = {
         'selector': 'source.ex - meta.attribute-with-value, source.exs, source.eex'
     }
-    inline_settings = None
-    inline_overrides = None
-    comment_re = None
-


### PR DESCRIPTION
As of newer version of SublimeLinter, this plugin stopped working with
deprecation messages, and is being disabled in SublimeLinter. This
cleans up the deprecated stuff, allowing the plugin to load again.